### PR TITLE
Add clk_flags to i2c param configuration

### DIFF
--- a/src/I2Cbus.cpp
+++ b/src/I2Cbus.cpp
@@ -82,6 +82,7 @@ esp_err_t I2C::begin(gpio_num_t sda_io_num, gpio_num_t scl_io_num, gpio_pullup_t
     conf.scl_io_num = scl_io_num;
     conf.scl_pullup_en = scl_pullup_en;
     conf.master.clk_speed = clk_speed;
+    conf.clk_flags = 0;
     esp_err_t err = i2c_param_config(port, &conf);
     if (!err) err = i2c_driver_install(port, conf.mode, 0, 0, 0);
     return err;


### PR DESCRIPTION
Without this flag, I get the error 
```i2c: i2c_param_config(640): i2c clock choice is invalid, please check flag and frequency```

Tested on:
ESP-IDF v4.4-dev-1849-g8e3e65a47