### PR TITLE
Improved performance for Read and Write

### DIFF
--- a/src/I2Cbus.cpp
+++ b/src/I2Cbus.cpp
@@ -126,14 +126,17 @@ esp_err_t I2C::writeByte(uint8_t devAddr, uint8_t regAddr, uint8_t data, int32_t
 }
 
 esp_err_t I2C::writeBytes(uint8_t devAddr, uint8_t regAddr, size_t length, const uint8_t *data, int32_t timeout) {
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    uint8_t _cmdLinkBuffer[(6 * 20) + 20 + 1];   // 20 for each link + 20 for cmd itself
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create_static(_cmdLinkBuffer, sizeof(_cmdLinkBuffer));
+
     i2c_master_start(cmd);
     i2c_master_write_byte(cmd, (devAddr << 1) | I2C_MASTER_WRITE, I2C_MASTER_ACK_EN);
     i2c_master_write_byte(cmd, regAddr, I2C_MASTER_ACK_EN);
     i2c_master_write(cmd, (uint8_t*) data, length, I2C_MASTER_ACK_EN);
     i2c_master_stop(cmd);
+
     esp_err_t err = i2c_master_cmd_begin(port, cmd, (timeout < 0 ? ticksToWait : pdMS_TO_TICKS(timeout)));
-    i2c_cmd_link_delete(cmd);
+    i2c_cmd_link_delete_static(cmd);
 #if defined CONFIG_I2CBUS_LOG_READWRITES
     if (!err) {
         char str[length*5+1];
@@ -181,7 +184,9 @@ esp_err_t I2C::readByte(uint8_t devAddr, uint8_t regAddr, uint8_t *data, int32_t
 }
 
 esp_err_t I2C::readBytes(uint8_t devAddr, uint8_t regAddr, size_t length, uint8_t *data, int32_t timeout) {
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    uint8_t _cmdLinkBuffer[(8 * 20) + 20 + 1];   // 20 for each link + 20 for cmd itself
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create_static(_cmdLinkBuffer, sizeof(_cmdLinkBuffer));
+
     i2c_master_start(cmd);
     i2c_master_write_byte(cmd, (devAddr << 1) | I2C_MASTER_WRITE, I2C_MASTER_ACK_EN);
     i2c_master_write_byte(cmd, regAddr, I2C_MASTER_ACK_EN);
@@ -189,8 +194,9 @@ esp_err_t I2C::readBytes(uint8_t devAddr, uint8_t regAddr, size_t length, uint8_
     i2c_master_write_byte(cmd, (devAddr << 1) | I2C_MASTER_READ, I2C_MASTER_ACK_EN);
     i2c_master_read(cmd, data, length, I2C_MASTER_LAST_NACK);
     i2c_master_stop(cmd);
+
     esp_err_t err = i2c_master_cmd_begin(port, cmd, (timeout < 0 ? ticksToWait : pdMS_TO_TICKS(timeout)));
-    i2c_cmd_link_delete(cmd);
+    i2c_cmd_link_delete_static(cmd);
 #if defined CONFIG_I2CBUS_LOG_READWRITES
     if (!err) {
         char str[length*5+1];


### PR DESCRIPTION
## Info
Improved performance by using static buffers instead of heap-allocated command chain. Improves performance drastially if many I2C commands are sent and read in a row.